### PR TITLE
Added support for opensuse rolling distros

### DIFF
--- a/config/config.toml.default
+++ b/config/config.toml.default
@@ -108,6 +108,12 @@ enabled = true
 # "leap", "leap-micro", "jump"
 editions = ["leap"]
 
+[OperatingSystems.Linux.OpenSUSERolling]
+enabled = true
+# Available editions:
+# "MicroOS-DVD", "Tumbleweed-DVD", "Tumbleweed-NET", "Tumbleweed-GNOME-Live", "Tumbleweed-KDE-Live", "Tumbleweed-XFCE-Live", "Tumbleweed-Rescue-CD"
+editions = ["Tumbleweed-NET", "Tumbleweed-DVD"]
+
 [OperatingSystems.Linux.RockyLinux]
 enabled = true
 # Available editions:

--- a/modules/updaters/OpenSUSERolling.py
+++ b/modules/updaters/OpenSUSERolling.py
@@ -1,0 +1,81 @@
+from functools import cache
+from pathlib import Path
+
+import logging
+
+import re
+import requests
+
+from modules.updaters.GenericUpdater import GenericUpdater
+from modules.utils import parse_hash, sha256_hash_check
+
+DOMAIN = "https://download.opensuse.org"
+DOWNLOAD_PAGE_URL = f"{DOMAIN}/download/tumbleweed/iso"
+FILE_NAME = "openSUSE-[[EDITION]]-x86_64-[[VER]].iso"
+
+
+class OpenSUSERolling(GenericUpdater):
+    """
+    A class representing an updater for OpenSUSE.
+
+    Attributes:
+        valid_editions (list[str]): List of valid editions to use
+        edition (str): Edition to download
+
+    Note:
+        This class inherits from the abstract base class GenericUpdater.
+    """
+
+    def __init__(self, folder_path: Path, edition: str) -> None:
+        self.valid_editions = ["MicroOS-DVD", "Tumbleweed-DVD", "Tumbleweed-NET", "Tumbleweed-GNOME-Live", "Tumbleweed-KDE-Live", "Tumbleweed-XFCE-Live", "Tumbleweed-Rescue-CD"]
+        self.edition = edition
+
+        self.download_page_url = DOWNLOAD_PAGE_URL
+        file_path = folder_path / FILE_NAME
+        super().__init__(file_path)
+
+    def _capitalize_edition(self) -> str:
+        for capEdition in self.valid_editions:
+            if capEdition.lower() is self.edition.lower():
+                return capEdition
+        # shouldn't get here
+        return self.edition
+
+    @cache
+    def _get_download_link(self) -> str:
+        isoFile = FILE_NAME.replace("[[EDITION]]", self._capitalize_edition()).replace("[[VER]]","Current")
+        return f"{self.download_page_url}/{isoFile}"
+
+
+    def check_integrity(self) -> bool:
+        sha256_url = f"{self._get_download_link()}.sha256"
+
+        sha256_sums = requests.get(sha256_url).text
+
+        sha256_sum = parse_hash(sha256_sums, [], 0)
+
+        return sha256_hash_check(
+            self._get_complete_normalized_file_path(absolute=True),
+            sha256_sum,
+        )
+
+    def _get_latest_version(self) -> list[str]:
+        sha256_url = f"{self._get_download_link()}.sha256"
+        sha256_sums = requests.get(sha256_url).text
+        return self._str_to_version(sha256_sums.split(" ")[-1])
+
+    def _str_to_version(self, version_str: str):
+        version = "0"
+        pattern = r'^.*Snapshot(\d*)-.*$'
+
+        match = re.search(pattern, version_str)
+        if match:
+            version = match.group(1)
+
+        logging.debug(
+            f"[OpenSUSERolling._parse_version] parsing:{version_str}, found version:{version}"
+        )
+        return [version]
+
+    def _version_to_str(self, version):
+        return f"Snapshot{version[0]}-Media"

--- a/modules/updaters/__init__.py
+++ b/modules/updaters/__init__.py
@@ -13,6 +13,7 @@ from .LinuxMint import LinuxMint
 from .Manjaro import Manjaro
 from .MemTest86Plus import MemTest86Plus
 from .OpenSUSE import OpenSUSE
+from .OpenSUSERolling import OpenSUSERolling
 from .RockyLinux import RockyLinux
 from .Tails import Tails
 from .Rescuezilla import Rescuezilla
@@ -43,6 +44,7 @@ __all__ = [
     "Manjaro",
     "MemTest86Plus",
     "OpenSUSE",
+    "OpenSUSERolling",
     "RockyLinux",
     "Tails",
     "Rescuezilla",

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -256,6 +256,7 @@ def download_file(url: str, local_file: Path, progress_bar: bool = True) -> None
                         total=total_size,
                         unit="B",
                         desc=part_file.name,
+                        unit_scale=True
                     ) as pbar:
                         for chunk in r.iter_content(chunk_size=1024):
                             if chunk:


### PR DESCRIPTION
Added Support for OpenSUSE rolling distros: 
"MicroOS-DVD", "Tumbleweed-DVD", "Tumbleweed-NET", "Tumbleweed-GNOME-Live", "Tumbleweed-KDE-Live", "Tumbleweed-XFCE-Live", "Tumbleweed-Rescue-CD"

This Closes #11 and maybe #13

This was accomplished by adding a separate updater called OpenSUSERolling.py. This was necessary to keep the code clean since OpenSUSE's rolling distro files are organized differently from their ie leap distros. 