### PR TITLE
Fix ShredOS checksum

### DIFF
--- a/modules/updaters/ShredOS.py
+++ b/modules/updaters/ShredOS.py
@@ -1,6 +1,8 @@
 from functools import cache
 from pathlib import Path
 
+import requests
+
 from modules.updaters.GenericUpdater import GenericUpdater
 from modules.updaters.util_update_checker import (
     github_get_latest_version,
@@ -40,18 +42,15 @@ class ShredOS(GenericUpdater):
         )
 
     def check_integrity(self) -> bool:
-        sha1_sums = self.release_info["text"]
+        img_url = self._get_download_link()
+        img_filename = img_url.split("/")[-1]
+        sha1_url = self.release_info["files"][f"{img_filename}.sha1"]
 
-        sha1_sum = parse_hash(
-            sha1_sums,
-            [
-                "sha1",
-                self._version_to_str(self._get_latest_version()),
-                "x86-64",
-                ".img",
-            ],
-            1,
-        )
+        sha1_response = requests.get(sha1_url)
+        if sha1_response.status_code != 200:
+            raise ConnectionError(f"Failed to fetch SHA1 checksum from '{sha1_url}'")
+
+        sha1_sum = parse_hash(sha1_response.text, [], 0)
 
         return sha1_hash_check(
             self._get_complete_normalized_file_path(absolute=True),


### PR DESCRIPTION
Before:
```shell
2026-03-16 13:11:47,716 - ERROR - [ShredOS] An error occurred while updating. See traceback below.
Traceback (most recent call last):
  File "/Users/user/git/SuperISOUpdater/venv-superisoupdater/lib/python3.14/site-packages/modules/updaters/GenericUpdater.py", line 124, in install_latest_version
    integrity_check = self.check_integrity()
  File "/Users/user/git/SuperISOUpdater/venv-superisoupdater/lib/python3.14/site-packages/modules/updaters/ShredOS.py", line 45, in check_integrity
    sha1_sum = parse_hash(
        sha1_sums,
    ...<6 lines>...
        1,
    )
  File "/Users/user/git/SuperISOUpdater/venv-superisoupdater/lib/python3.14/site-packages/modules/utils.py", line 224, in parse_hash
    hash = next(
        line.split()[hash_position_in_line]
        for line in hashes.strip().splitlines()
        if all(match in line for match in match_strings_in_line)
    )
StopIteration

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/user/git/SuperISOUpdater/venv-superisoupdater/lib/python3.14/site-packages/sisou.py", line 65, in run_updater
    updater.install_latest_version()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/Users/user/git/SuperISOUpdater/venv-superisoupdater/lib/python3.14/site-packages/modules/updaters/GenericUpdater.py", line 131, in install_latest_version
    raise IntegrityCheckError(
        "Integrity check failed: An error occurred"
    ) from e
modules.exceptions.IntegrityCheckError: Integrity check failed: An error occurred
```

After
```shell
2026-03-16 13:19:09,299 - INFO - [ShredOS] Updates available. Downloading and installing the latest version...
shredos-2025.11.part: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 373M/373M [00:07<00:00, 47.8MB/s]
2026-03-16 13:19:18,070 - INFO - [ShredOS] Update completed successfully!
``` 