### PR TITLE
Mirrors: Correct version error URLs

### DIFF
--- a/modules/mirrors/CachyOS/ATCachyOS.py
+++ b/modules/mirrors/CachyOS/ATCachyOS.py
@@ -42,7 +42,7 @@ class ATCachyOS(GenericHTTPMirror):
                 latest_version = current_version
 
         if latest_version == Version("0", separator=""):
-            raise ValueError(f"No version found on the page '{self.uri}'")
+            raise ValueError(f"No version found on the page '{r.url}'")
         return latest_version
 
     def _determine_public_key(self) -> bytes | None:

--- a/modules/mirrors/CachyOS/USCachyOS.py
+++ b/modules/mirrors/CachyOS/USCachyOS.py
@@ -42,7 +42,7 @@ class USCachyOS(GenericHTTPMirror):
                 latest_version = current_version
 
         if latest_version == Version("0", separator=""):
-            raise ValueError(f"No version found on the page '{self.uri}'")
+            raise ValueError(f"No version found on the page '{r.url}'")
         return latest_version
 
     def _determine_public_key(self) -> bytes | None:

--- a/modules/mirrors/LinuxMint/Kernel.py
+++ b/modules/mirrors/LinuxMint/Kernel.py
@@ -45,7 +45,7 @@ class Kernel(GenericHTTPMirror):
                 latest_version = current_version
 
         if latest_version == Version("0"):
-            raise ValueError(f"No version found on the page '{self.uri}'")
+            raise ValueError(f"No version found on the page '{r.url}'")
         return latest_version
 
     def _determine_public_key(self) -> bytes | None:

--- a/modules/mirrors/LinuxMint/LinuxMint.py
+++ b/modules/mirrors/LinuxMint/LinuxMint.py
@@ -43,7 +43,7 @@ class LinuxMint(GenericHTTPMirror):
                 latest_version = current_version
 
         if latest_version == Version("0"):
-            raise ValueError(f"No version found on the page '{self.uri}'")
+            raise ValueError(f"No version found on the page '{r.url}'")
         return latest_version
 
     def _determine_public_key(self) -> bytes | None:

--- a/modules/mirrors/NetBSD/NetBSD.py
+++ b/modules/mirrors/NetBSD/NetBSD.py
@@ -37,7 +37,7 @@ class NetBSD(GenericHTTPMirror):
                 latest_version = current_version
 
         if latest_version == Version("0"):
-            raise ValueError(f"No version found on the page '{self.uri}'")
+            raise ValueError(f"No version found on the page '{r.url}'")
         return latest_version
 
     def _fetch_and_parse_sum(self, url: str) -> tuple[str, int]:

--- a/modules/mirrors/NetBSD/NetBSDCDN.py
+++ b/modules/mirrors/NetBSD/NetBSDCDN.py
@@ -37,7 +37,7 @@ class NetBSDCDN(GenericHTTPMirror):
                 latest_version = current_version
 
         if latest_version == Version("0"):
-            raise ValueError(f"No version found on the page '{self.uri}'")
+            raise ValueError(f"No version found on the page '{r.url}'")
         return latest_version
 
     def _fetch_and_parse_sum(self, url: str) -> tuple[str, int]:

--- a/modules/mirrors/NetBSD/NetBSDFR.py
+++ b/modules/mirrors/NetBSD/NetBSDFR.py
@@ -37,7 +37,7 @@ class NetBSDFR(GenericHTTPMirror):
                 latest_version = current_version
 
         if latest_version == Version("0"):
-            raise ValueError(f"No version found on the page '{self.uri}'")
+            raise ValueError(f"No version found on the page '{r.url}'")
         return latest_version
 
     def _fetch_and_parse_sum(self, url: str) -> tuple[str, int]:

--- a/modules/mirrors/OPNsense/OPNsense.py
+++ b/modules/mirrors/OPNsense/OPNsense.py
@@ -42,7 +42,7 @@ class OPNsense(GenericHTTPMirror):
                 latest_version = current_version
 
         if latest_version == Version("0"):
-            raise ValueError(f"No version found on the page '{self.uri}'")
+            raise ValueError(f"No version found on the page '{r.url}'")
         return latest_version
 
     def download_and_verify(self, file) -> None:

--- a/modules/mirrors/Ubuntu/OVH.py
+++ b/modules/mirrors/Ubuntu/OVH.py
@@ -44,7 +44,7 @@ class OVH(GenericHTTPMirror):
                 latest_version = current_version
 
         if latest_version == Version("0"):
-            raise ValueError(f"No version found on the page '{self.uri}'")
+            raise ValueError(f"No version found on the page '{r.url}'")
         return latest_version
 
     def _determine_public_key(self) -> bytes | None:

--- a/modules/mirrors/UbuntuFlavor/MirrorService.py
+++ b/modules/mirrors/UbuntuFlavor/MirrorService.py
@@ -43,7 +43,7 @@ class MirrorService(GenericHTTPMirror):
                 latest_version = current_version
 
         if latest_version == Version("0"):
-            raise ValueError(f"No version found on the page '{self.uri}'")
+            raise ValueError(f"No version found on the page '{r.url}'")
         return latest_version
 
     def _determine_public_key(self) -> bytes | None:

--- a/modules/mirrors/UbuntuFlavor/Ubuntu.py
+++ b/modules/mirrors/UbuntuFlavor/Ubuntu.py
@@ -43,7 +43,7 @@ class Ubuntu(GenericHTTPMirror):
                 latest_version = current_version
 
         if latest_version == Version("0"):
-            raise ValueError(f"No version found on the page '{self.uri}'")
+            raise ValueError(f"No version found on the page '{r.url}'")
         return latest_version
 
     def _determine_public_key(self) -> bytes | None:


### PR DESCRIPTION
When a mirror implementation does its own HTTP GET during version lookups, the `self.uri` is generally (a) not yet set, and (b) not the correct URL to report for version lookup errors. This change switches these to the URL actually consulted by the version lookups in these cases.