### PR TITLE
Fedora/*buntu: Version Lookup Resilience

### DIFF
--- a/modules/mirrors/Fedora/Fedora.py
+++ b/modules/mirrors/Fedora/Fedora.py
@@ -35,7 +35,7 @@ class Fedora(GenericHTTPMirror):
         )
         r.raise_for_status()
 
-        versions = re.findall(r'href="(\d+)/"', r.text)
+        versions = re.findall(r'href="(?:\./)?(\d+)/?"', r.text)
         if not versions:
             raise ValueError(f"No version found on the page '{r.url}'")
 

--- a/modules/mirrors/UbuntuFlavor/MirrorService.py
+++ b/modules/mirrors/UbuntuFlavor/MirrorService.py
@@ -26,24 +26,39 @@ class MirrorService(GenericHTTPMirror):
         )
 
     def _determine_latest_version(self) -> Version:
-        r = self.session.get(
+        ver_r = self.session.get(
             f"https://www.mirrorservice.org/sites/cdimage.ubuntu.com/cdimage/{self.flavor}/releases/",
         )
-        r.raise_for_status()
-        soup = BeautifulSoup(r.content, features="html.parser")
-        urls = [str(a_tag.get("href")) for a_tag in soup.find_all("a", href=True)]
+        ver_r.raise_for_status()
+        ver_soup = BeautifulSoup(ver_r.content, features="html.parser")
+        ver_urls = [
+            str(a_tag.get("href")) for a_tag in ver_soup.find_all("a", href=True)
+        ]
 
         latest_version = Version("0")
-        for url in urls:
-            ver_match = re.match(r"^([\d\.]+)\/?$", url)
+        for ver_url in ver_urls:
+            ver_match = re.match(r"^([\d\.]+)\/?$", ver_url)
             if not ver_match:
                 continue
             current_version = Version(ver_match.group(1))
-            if current_version and current_version > latest_version:
-                latest_version = current_version
+            if current_version:
+                # Need to filter out pre-releases
+                rel_r = self.session.get(
+                    f"https://www.mirrorservice.org/sites/cdimage.ubuntu.com/cdimage/{self.flavor}/releases/{current_version}/",
+                )
+                rel_r.raise_for_status()
+                rel_soup = BeautifulSoup(rel_r.content, features="html.parser")
+                rel_urls = [
+                    str(a_tag.get("href"))
+                    for a_tag in rel_soup.find_all("a", href=True)
+                ]
+
+                for rel_url in rel_urls:
+                    if rel_url == "release/" and current_version > latest_version:
+                        latest_version = current_version
 
         if latest_version == Version("0"):
-            raise ValueError(f"No version found on the page '{r.url}'")
+            raise ValueError(f"No version found on the page '{ver_r.url}'")
         return latest_version
 
     def _determine_public_key(self) -> bytes | None:

--- a/modules/mirrors/UbuntuFlavor/MirrorService.py
+++ b/modules/mirrors/UbuntuFlavor/MirrorService.py
@@ -36,12 +36,12 @@ class MirrorService(GenericHTTPMirror):
         ]
 
         latest_version = Version("0")
-        for ver_url in ver_urls:
+        for ver_url in sorted(ver_urls, reverse=True):
             ver_match = re.match(r"^([\d\.]+)\/?$", ver_url)
             if not ver_match:
                 continue
             current_version = Version(ver_match.group(1))
-            if current_version:
+            if current_version and current_version > latest_version:
                 # Need to filter out pre-releases
                 rel_r = self.session.get(
                     f"https://www.mirrorservice.org/sites/cdimage.ubuntu.com/cdimage/{self.flavor}/releases/{current_version}/",
@@ -54,7 +54,7 @@ class MirrorService(GenericHTTPMirror):
                 ]
 
                 for rel_url in rel_urls:
-                    if rel_url == "release/" and current_version > latest_version:
+                    if rel_url == "release/":
                         latest_version = current_version
 
         if latest_version == Version("0"):

--- a/modules/mirrors/UbuntuFlavor/Ubuntu.py
+++ b/modules/mirrors/UbuntuFlavor/Ubuntu.py
@@ -36,12 +36,12 @@ class Ubuntu(GenericHTTPMirror):
         ]
 
         latest_version = Version("0")
-        for ver_url in ver_urls:
+        for ver_url in sorted(ver_urls, reverse=True):
             ver_match = re.match(r"^([\d\.]+)\/?$", ver_url)
             if not ver_match:
                 continue
             current_version = Version(ver_match.group(1))
-            if current_version:
+            if current_version and current_version > latest_version:
                 # Need to filter out pre-releases
                 rel_r = self.session.get(
                     f"http://cdimages.ubuntu.com/{self.flavor}/releases/{current_version}/",
@@ -54,7 +54,7 @@ class Ubuntu(GenericHTTPMirror):
                 ]
 
                 for rel_url in rel_urls:
-                    if rel_url == "release/" and current_version > latest_version:
+                    if rel_url == "release/":
                         latest_version = current_version
 
         if latest_version == Version("0"):

--- a/modules/mirrors/UbuntuFlavor/Ubuntu.py
+++ b/modules/mirrors/UbuntuFlavor/Ubuntu.py
@@ -26,24 +26,39 @@ class Ubuntu(GenericHTTPMirror):
         )
 
     def _determine_latest_version(self) -> Version:
-        r = self.session.get(
+        ver_r = self.session.get(
             f"http://cdimages.ubuntu.com/{self.flavor}/releases/",
         )
-        r.raise_for_status()
-        soup = BeautifulSoup(r.content, features="html.parser")
-        urls = [str(a_tag.get("href")) for a_tag in soup.find_all("a", href=True)]
+        ver_r.raise_for_status()
+        ver_soup = BeautifulSoup(ver_r.content, features="html.parser")
+        ver_urls = [
+            str(a_tag.get("href")) for a_tag in ver_soup.find_all("a", href=True)
+        ]
 
         latest_version = Version("0")
-        for url in urls:
-            ver_match = re.match(r"^([\d\.]+)\/?$", url)
+        for ver_url in ver_urls:
+            ver_match = re.match(r"^([\d\.]+)\/?$", ver_url)
             if not ver_match:
                 continue
             current_version = Version(ver_match.group(1))
-            if current_version and current_version > latest_version:
-                latest_version = current_version
+            if current_version:
+                # Need to filter out pre-releases
+                rel_r = self.session.get(
+                    f"http://cdimages.ubuntu.com/{self.flavor}/releases/{current_version}/",
+                )
+                rel_r.raise_for_status()
+                rel_soup = BeautifulSoup(rel_r.content, features="html.parser")
+                rel_urls = [
+                    str(a_tag.get("href"))
+                    for a_tag in rel_soup.find_all("a", href=True)
+                ]
+
+                for rel_url in rel_urls:
+                    if rel_url == "release/" and current_version > latest_version:
+                        latest_version = current_version
 
         if latest_version == Version("0"):
-            raise ValueError(f"No version found on the page '{r.url}'")
+            raise ValueError(f"No version found on the page '{ver_r.url}'")
         return latest_version
 
     def _determine_public_key(self) -> bytes | None:


### PR DESCRIPTION
For Fedora: There is sometimes an incosistency between how different mirrors present versions in links - `44/` vs `./44`, mainly.  This updates the regex to properly support the alternate formats.

For Flavored Ubuntu: Unlike the mainline distirbution, Flavored Ubuntu has already posted snapshot ISOs for 26.10. It's more overhead than I'd prefer, but to prevent failing to grab a release ISO for a version that doesn't have one yet, I added a check for whether each version has a `release/` subfolder - only released versions match.