### PR TITLE
Proxmox: Add Signature Support

### DIFF
--- a/modules/mirrors/Proxmox/Proxmox.py
+++ b/modules/mirrors/Proxmox/Proxmox.py
@@ -1,5 +1,11 @@
+import re
+
+from bs4 import BeautifulSoup
+from datetime import datetime
+from modules.Checksum import SHA256Sum
 from modules.DotDashVersion import DotDashVersion
 from modules.mirrors.GenericHTTPMirror import GenericHTTPMirror
+from modules.utils import parse_hash
 
 
 class Proxmox(GenericHTTPMirror):
@@ -9,6 +15,44 @@ class Proxmox(GenericHTTPMirror):
             download_regex=rf"proxmox-{edition}_(.+)\.iso",
             version_regex=rf"proxmox-{edition}_(.+)\.iso",
             version_class=DotDashVersion,
-            # There is a signature, but the key is not stated, so it's useless...
-            has_signature=False,
         )
+
+    def _determine_public_key(self) -> bytes:
+        # https://enterprise.proxmox.com/iso/#verify indicates use of a single `release` key, but the actual signatures use multiple, so verification fails. Instead, use the `archive-keyring`.
+        key_index_url = "https://enterprise.proxmox.com/debian/"
+        key_line_regex = r"(?P<filename>.+\.gpg)\s{2,}(?P<modified>\d{2}-(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-\d{4} \d{2}:\d{2})\s{2,}(?P<size>\d+)"
+
+        idx_r = self.session.get(key_index_url, headers=self.headers)
+        idx_r.raise_for_status()
+        idx_soup = BeautifulSoup(idx_r.content, features="html.parser")
+
+        pre_tag = idx_soup.find("pre")
+        if not pre_tag:
+            raise ValueError(
+                f"Invalid file listing on {key_index_url} - cannot retrieve Proxmox public key for signature verification!"
+            )
+
+        pre_lines = pre_tag.get_text().strip().splitlines()
+        key_lines = sorted(
+            [
+                re.match(key_line_regex, key_line)
+                for key_line in pre_lines
+                if "archive-keyring" in key_line
+            ],
+            key=lambda x: datetime.strptime(x["modified"], "%d-%b-%Y %H:%M"),
+            reverse=True,
+        )
+
+        key_r = self.session.get(f"{key_index_url}{key_lines[0]['filename']}")
+        key_r.raise_for_status()
+        return key_r.content
+
+    def _determine_signature(self) -> bytes | None:
+        r = self.session.get(f"{self.download_link}.asc")
+        r.raise_for_status()
+        return r.content
+
+    def _determine_sums(self):
+        r = self.session.get(f"{self.download_link}.sha256")
+        r.raise_for_status()
+        return [SHA256Sum(parse_hash(r.text, self._download_regex, 0))]


### PR DESCRIPTION
Proxmox has signed their ISO releases for some time, but the documentation on how to validate those signatures is ... difficult to find, and inaccurate at best. After some trial and error, I've worked out how to *actually* validate these signatures programmatically. The result is this change.

Finding the signature itself is straightforward - just add `.asc` to the ISO filename. Finding the key file, however, is more involved. Proxmox documentation states that ISOs are signed with the associated `release` key, which is half true. However, it also states to validate the signatures using only that key, which *doesn't* work - the ISOs are actually signed with the *previous* key as well, causing validation to fail on the (missing) second key.

Luckily, there *is* a single 'archive-keyring' file with *both* keys inside, so we can use that. *Unluckily*, that file's name *still* includes the name of the latest release, despite covering multiple. So we need to look up the most recent of those by date - and since the directory listing is provided as preformatted text, we get to parse that ourselves. In order to avoid pulling in another dependency, I've hardcoded the current date formatting used by the index page (`datetime.strptime()` requires an explicit format string), but should that ever change, the regex and format string will need to be updated to match.